### PR TITLE
Fix problem with exception when elasticsearch has been turn off.

### DIFF
--- a/public/authz/index.js
+++ b/public/authz/index.js
@@ -15,17 +15,17 @@ import DashboardListingDecorator from "./decorations/DashboardListingDecorator";
 import HomeRouteDecoration from "./decorations/HomeRouteDecoration";
 
 import authorizationRules from "./authorizationRules";
-import {isFeatureEnabled, isKibanaApp} from "./utils";
+import {isFeatureEnabled, isKibanaApp, decorate} from "./utils";
 
-uiModules.get('kibana', ['ngRoute', 'react'])
-    .decorator('appSwitcherDirective', AppSwitcherDecorator);
+const kibanaApp = uiModules.get('kibana', ['ngRoute', 'react']);
+decorate(kibanaApp, 'appSwitcher', AppSwitcherDecorator);
 
 if (isKibanaApp()) {
-    const dashboardApp = uiModules.get('app/dashboard')
-        .decorator('dashboardAppDirective', DashboardAppDecorator);
+    const dashboardApp = uiModules.get('app/dashboard');
+    decorate(dashboardApp, 'dashboardApp', DashboardAppDecorator);
 
     if (isFeatureEnabled('acl') || isFeatureEnabled('tagging')) {
-        dashboardApp.decorator('dashboardListingDirective', DashboardListingDecorator);
+        decorate(dashboardApp, 'dashboardListing', DashboardListingDecorator);
     }
 }
 

--- a/public/authz/index.js
+++ b/public/authz/index.js
@@ -15,17 +15,17 @@ import DashboardListingDecorator from "./decorations/DashboardListingDecorator";
 import HomeRouteDecoration from "./decorations/HomeRouteDecoration";
 
 import authorizationRules from "./authorizationRules";
-import {isFeatureEnabled, isKibanaApp, decorate} from "./utils";
+import {isFeatureEnabled, isKibanaApp, decorateDirective} from "./utils";
 
 const kibanaApp = uiModules.get('kibana', ['ngRoute', 'react']);
-decorate(kibanaApp, 'appSwitcher', AppSwitcherDecorator);
+decorateDirective(kibanaApp, 'appSwitcher', AppSwitcherDecorator);
 
 if (isKibanaApp()) {
     const dashboardApp = uiModules.get('app/dashboard');
-    decorate(dashboardApp, 'dashboardApp', DashboardAppDecorator);
+    decorateDirective(dashboardApp, 'dashboardApp', DashboardAppDecorator);
 
     if (isFeatureEnabled('acl') || isFeatureEnabled('tagging')) {
-        decorate(dashboardApp, 'dashboardListing', DashboardListingDecorator);
+        decorateDirective(dashboardApp, 'dashboardListing', DashboardListingDecorator);
     }
 }
 

--- a/public/authz/utils.js
+++ b/public/authz/utils.js
@@ -4,13 +4,13 @@ export const isKibanaApp = () => (window.location.pathname || '').endsWith('/app
 
 export const isFeatureEnabled = (featureName) => chrome.getInjected(`keycloak.features.${featureName}`);
 
-export const isDirectiveExist = (module, directive) => module._invokeQueue
+const directiveExists = (module, directive) => module._invokeQueue
     .filter(item => 'directive' === item[1])
     .map(item => item[2][0])
     .includes(directive);
 
-export const decorate = (module, directive, decorator) => {
-    if (isDirectiveExist(module, directive)) {
+export const decorateDirective = (module, directive, decorator) => {
+    if (directiveExists(module, directive)) {
         module.decorator(directive.concat('Directive'), decorator);
     }
 };

--- a/public/authz/utils.js
+++ b/public/authz/utils.js
@@ -3,3 +3,14 @@ import chrome from 'ui/chrome';
 export const isKibanaApp = () => (window.location.pathname || '').endsWith('/app/kibana');
 
 export const isFeatureEnabled = (featureName) => chrome.getInjected(`keycloak.features.${featureName}`);
+
+export const isDirectiveExist = (module, directive) => module._invokeQueue
+    .filter(item => 'directive' === item[1])
+    .map(item => item[2][0])
+    .includes(directive);
+
+export const decorate = (module, directive, decorator) => {
+    if (isDirectiveExist(module, directive)) {
+        module.decorator(directive.concat('Directive'), decorator);
+    }
+};


### PR DESCRIPTION
Fixed the problem with falling of the Kibana with the stacktrace in case when the Elasticsearch was inactive and the Kibana's page was refreshed. In this situation we should be redirceted to the 'Kibana Status Page'.